### PR TITLE
Parsing function definition command

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -76,7 +76,8 @@ impl Command {
     pub async fn execute(&self, env: &mut dyn Env) -> Result {
         match self {
             Command::Simple(command) => command.execute(env).await,
-            Command::Compound { .. } => Ok(println!("{}", self)), // TODO execute compound command
+            Command::Compound(_) | Command::Function(_) => Ok(println!("{}", self)),
+            // TODO execute compound command / function definition
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -361,6 +361,8 @@ impl Parser<'_> {
         // TODO reject invalid name if POSIXly-correct
 
         loop {
+            while self.newline_and_here_doc_contents().await? {}
+
             return match self.full_compound_command().await? {
                 Some(body) => Ok(Command::Function(FunctionDefinition {
                     has_keyword: false,
@@ -1511,7 +1513,7 @@ mod tests {
     }
 
     #[test]
-    fn parser_short_function_definition_alias() {
+    fn parser_short_function_definition_alias_and_newline() {
         let mut lexer = Lexer::with_source(Source::Unknown, " a b ");
         let mut aliases = AliasSet::new();
         let origin = Location::dummy("".to_string());
@@ -1529,7 +1531,7 @@ mod tests {
         ));
         aliases.insert(HashEntry::new(
             "c".to_string(),
-            "(:)".to_string(),
+            "\n\n(:)".to_string(),
             false,
             origin.clone(),
         ));

--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -55,6 +55,12 @@ pub enum ErrorCause {
     UnclosedSubshell { opening_location: Location },
     /// A subshell contains no commands.
     EmptySubshell,
+    /// The `(` is not followed by `)` in a function definition.
+    UnmatchedParenthesis,
+    /// The function body is missing in a function definition command.
+    MissingFunctionBody,
+    /// A function body is not a compound command.
+    InvalidFunctionBody,
     /// A pipeline is missing after a `&&` or `||` token.
     MissingPipeline(AndOr),
     /// Two successive `!` tokens.
@@ -76,6 +82,9 @@ impl PartialEq for ErrorCause {
             | (MissingHereDocDelimiter, MissingHereDocDelimiter)
             | (MissingHereDocContent, MissingHereDocContent)
             | (EmptySubshell, EmptySubshell)
+            | (UnmatchedParenthesis, UnmatchedParenthesis)
+            | (MissingFunctionBody, MissingFunctionBody)
+            | (InvalidFunctionBody, InvalidFunctionBody)
             | (DoubleNegation, DoubleNegation)
             | (BangAfterBar, BangAfterBar)
             | (MissingCommandAfterBang, MissingCommandAfterBang)
@@ -131,6 +140,9 @@ impl fmt::Display for ErrorCause {
                 opening_location: _,
             } => f.write_str("The subshell is not closed"),
             EmptySubshell => f.write_str("The subshell is missing its content"),
+            UnmatchedParenthesis => f.write_str("`)` is missing after `(`"),
+            MissingFunctionBody => f.write_str("The function body is missing"),
+            InvalidFunctionBody => f.write_str("The function body must be a compound command"),
             MissingPipeline(and_or) => {
                 write!(f, "A command is missing after `{}`", and_or)
             }

--- a/src/parser/fill.rs
+++ b/src/parser/fill.rs
@@ -155,6 +155,7 @@ impl Fill for Command<MissingHereDoc> {
         Ok(match self {
             Simple(c) => Simple(c.fill(i)?),
             Compound(c) => Compound(c.fill(i)?),
+            Function(c) => Function(c.fill(i)?),
         })
     }
 }

--- a/src/parser/fill.rs
+++ b/src/parser/fill.rs
@@ -131,6 +131,23 @@ impl Fill for FullCompoundCommand<MissingHereDoc> {
     }
 }
 
+impl Fill for FunctionDefinition<MissingHereDoc> {
+    type Full = FunctionDefinition;
+    fn fill(self, i: &mut dyn Iterator<Item = HereDoc>) -> Result<FunctionDefinition> {
+        let FunctionDefinition {
+            has_keyword,
+            name,
+            body,
+        } = self;
+        let body = body.fill(i)?;
+        Ok(FunctionDefinition {
+            has_keyword,
+            name,
+            body,
+        })
+    }
+}
+
 impl Fill for Command<MissingHereDoc> {
     type Full = Command;
     fn fill(self, i: &mut dyn Iterator<Item = HereDoc>) -> Result<Command> {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -445,6 +445,11 @@ impl<H> SimpleCommand<H> {
     pub fn is_empty(&self) -> bool {
         self.assigns.is_empty() && self.words.is_empty() && self.redirs.is_empty()
     }
+
+    /// Returns true if the simple command contains only one word.
+    pub fn is_one_word(&self) -> bool {
+        self.assigns.is_empty() && self.words.len() == 1 && self.redirs.is_empty()
+    }
 }
 
 impl fmt::Display for SimpleCommand {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -523,14 +523,16 @@ pub enum Command<H = HereDoc> {
     Simple(SimpleCommand<H>),
     /// Compound command.
     Compound(FullCompoundCommand<H>),
-    // TODO Function definition
+    /// Function definition command.
+    Function(FunctionDefinition<H>),
 }
 
 impl fmt::Display for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Command::Simple(c) => write!(f, "{}", c),
-            Command::Compound(c) => write!(f, "{}", c),
+            Command::Simple(c) => c.fmt(f),
+            Command::Compound(c) => c.fmt(f),
+            Command::Function(c) => c.fmt(f),
         }
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -496,6 +496,26 @@ impl fmt::Display for FullCompoundCommand {
     }
 }
 
+/// Function definition command.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FunctionDefinition<H = HereDoc> {
+    /// Whether the function definition command starts with the `function` reserved word.
+    pub has_keyword: bool,
+    /// Function name.
+    pub name: Word,
+    /// Function body.
+    pub body: FullCompoundCommand<H>,
+}
+
+impl fmt::Display for FunctionDefinition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.has_keyword {
+            f.write_str("function ")?;
+        }
+        write!(f, "{}() {}", self.name, self.body)
+    }
+}
+
 /// Element of a pipe sequence.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Command<H = HereDoc> {
@@ -894,6 +914,32 @@ mod tests {
             first,
             rest: vec![],
         }
+    }
+
+    fn dummy_list(s: String) -> List {
+        let and_or = dummy_and_or_list(s);
+        let is_async = false;
+        let item = Item { and_or, is_async };
+        List { items: vec![item] }
+    }
+
+    fn dummy_compound_command(s: String) -> CompoundCommand {
+        let list = dummy_list(s);
+        CompoundCommand::Subshell(list)
+    }
+
+    #[test]
+    fn function_definition_display() {
+        let body = FullCompoundCommand {
+            command: dummy_compound_command("bar".to_string()),
+            redirs: vec![],
+        };
+        let fd = FunctionDefinition {
+            has_keyword: false,
+            name: Word::with_str("foo".to_string()),
+            body,
+        };
+        assert_eq!(fd.to_string(), "foo() (bar)");
     }
 
     #[test]


### PR DESCRIPTION
- [x] Define function definition command syntax
- [x] Add the function definition command syntax to the command syntax
- [x] Define errors that may happen while parsing
  - (Invalid function name)
  - (Function name missing after `function`)
  - `(` not followed by `)`
  - Function body missing
  - Function body not being a compound command
- [x] Parse
- [ ] Handle the alias substitution corner cases
  - After `(`
  - After `)`
- [x] Allow linebreak after `()`
