### PR TITLE
Refactor alias substitution handling

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -54,7 +54,7 @@ impl Parser<'_> {
     /// needed after alias substitution.
     pub async fn take_token_aliased_fully(&mut self) -> Result<Token> {
         loop {
-            if let Rec::Parsed(t) = self.take_token_aliased(false).await? {
+            if let Rec::Parsed(t) = self.take_token_manual(false).await? {
                 return Ok(t);
             }
         }
@@ -206,7 +206,7 @@ impl Parser<'_> {
             }
 
             // Apply alias substitution
-            let token = match self.take_token_aliased(result.words.is_empty()).await? {
+            let token = match self.take_token_manual(result.words.is_empty()).await? {
                 Rec::AliasSubstituted => {
                     if result.is_empty() {
                         return Ok(Rec::AliasSubstituted);
@@ -370,7 +370,7 @@ impl Parser<'_> {
                     body,
                 })),
                 None => {
-                    let next = match self.take_token_aliased(false).await? {
+                    let next = match self.take_token_manual(false).await? {
                         Rec::AliasSubstituted => continue,
                         Rec::Parsed(next) => next,
                     };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -72,7 +72,7 @@ impl Parser<'_> {
             return Ok(None);
         }
 
-        let opening_location = self.take_token().await?.word.location;
+        let opening_location = self.take_token_raw().await?.word.location;
         let mut words = vec![];
 
         loop {
@@ -110,7 +110,7 @@ impl Parser<'_> {
         operator: RedirOp,
     ) -> Result<RedirBody<MissingHereDoc>> {
         // TODO reject >>| and <<< if POSIXly-correct
-        let operator_location = self.take_token().await?.word.location;
+        let operator_location = self.take_token_raw().await?.word.location;
         let operand = self.redirection_operand().await?.ok_or(Error {
             cause: ErrorCause::MissingRedirOperand,
             location: operator_location,
@@ -123,7 +123,7 @@ impl Parser<'_> {
         &mut self,
         remove_tabs: bool,
     ) -> Result<RedirBody<MissingHereDoc>> {
-        let operator_location = self.take_token().await?.word.location;
+        let operator_location = self.take_token_raw().await?.word.location;
         let delimiter = self.redirection_operand().await?.ok_or(Error {
             cause: ErrorCause::MissingHereDocDelimiter,
             location: operator_location,
@@ -269,12 +269,12 @@ impl Parser<'_> {
     /// - [`ErrorCause::UnclosedSubshell`]
     /// - [`ErrorCause::EmptySubshell`]
     async fn subshell(&mut self) -> Result<CompoundCommand<MissingHereDoc>> {
-        let open = self.take_token().await?;
+        let open = self.take_token_raw().await?;
         assert_eq!(open.id, Operator(OpenParen));
 
         let list = self.maybe_compound_list_boxed().await?;
 
-        let close = self.take_token().await?;
+        let close = self.take_token_raw().await?;
         if close.id != Operator(CloseParen) {
             return Err(Error {
                 cause: ErrorCause::UnclosedSubshell {
@@ -345,7 +345,7 @@ impl Parser<'_> {
             return Ok(Command::Simple(intro));
         }
 
-        let open = self.take_token().await?;
+        let open = self.take_token_raw().await?;
         debug_assert_eq!(open.id, Operator(OpenParen));
 
         let close = self.take_token_aliased_fully().await?;
@@ -416,7 +416,7 @@ impl Parser<'_> {
             Rec::Parsed(None) => {
                 // Parse the `!` reserved word
                 if let Token(Some(Keyword::Bang)) = self.peek_token().await?.id {
-                    let location = self.take_token().await?.word.location;
+                    let location = self.take_token_raw().await?.word.location;
                     loop {
                         // Parse the command after the `!`
                         if let Rec::Parsed(option) = self.command().await? {
@@ -443,7 +443,7 @@ impl Parser<'_> {
         // Parse `|`
         let mut commands = vec![Rc::new(first)];
         while self.peek_token().await?.id == Operator(Bar) {
-            let bar_location = self.take_token().await?.word.location;
+            let bar_location = self.take_token_raw().await?.word.location;
 
             while self.newline_and_here_doc_contents().await? {}
 
@@ -492,7 +492,7 @@ impl Parser<'_> {
                 Operator(BarBar) => AndOr::OrElse,
                 _ => break,
             };
-            self.take_token().await?;
+            self.take_token_raw().await?;
 
             while self.newline_and_here_doc_contents().await? {}
 
@@ -550,7 +550,7 @@ impl Parser<'_> {
             if !next {
                 break;
             }
-            self.take_token().await?;
+            self.take_token_raw().await?;
 
             let result = loop {
                 if let Rec::Parsed(result) = self.and_or_list().await? {
@@ -576,7 +576,7 @@ impl Parser<'_> {
             return Ok(false);
         }
 
-        self.take_token().await?;
+        self.take_token_raw().await?;
         self.here_doc_contents().await?;
         Ok(true)
     }

--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -371,7 +371,7 @@ impl Parser<'_> {
     ///
     /// This function does not perform alias substitution. In most cases you should use
     /// [`take_token_aliased`](Parser::take_token_aliased) instead.
-    pub async fn take_token(&mut self) -> Result<Token> {
+    pub async fn take_token_raw(&mut self) -> Result<Token> {
         self.require_token().await;
         self.token.take().unwrap()
     }
@@ -400,7 +400,7 @@ impl Parser<'_> {
     /// call this function on a reserved word. To consume a reserved word, you
     /// should call [`take_token`](Self::take_token).
     pub async fn take_token_aliased(&mut self, is_command_name: bool) -> Result<Rec<Token>> {
-        let token = self.take_token().await?;
+        let token = self.take_token_raw().await?;
 
         if !self.aliases.is_empty() {
             if let Some(name) = token.word.to_string_if_literal() {

--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -366,14 +366,14 @@ impl Parser<'_> {
         self.token.as_ref().unwrap().as_ref().map_err(|e| e.clone())
     }
 
-    // TODO Consider making this function private in favor of take_token_aliased(_fully)
     /// Consumes the current token.
     ///
     /// If the current token is not yet read from the underlying lexer, it is read.
     ///
     /// This function does not perform alias substitution. In most cases you should use
-    /// [`take_token_aliased`](Parser::take_token_aliased) instead.
-    pub async fn take_token_raw(&mut self) -> Result<Token> {
+    /// [`take_token_manual`](Self::take_token_manual) or
+    /// [`take_token_auto`](Self::take_token_auto) instead.
+    async fn take_token_raw(&mut self) -> Result<Token> {
         self.require_token().await;
         self.token.take().unwrap()
     }

--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -377,7 +377,7 @@ impl Parser<'_> {
     }
 
     // TODO Only POSIXly-valid alias name should be recognized in POSIXly-correct mode.
-    /// Consumes the current token if it is not an alias.
+    /// Consumes the current token after performing applicable alias substitution.
     ///
     /// If the current token is not yet read from the underlying lexer, it is read.
     ///

--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -397,9 +397,10 @@ impl Parser<'_> {
     ///
     /// However, alias substitution should _not_ be performed on a reserved word
     /// in any case. It is your responsibility to check the token type and not to
-    /// call this function on a reserved word. To consume a reserved word, you
-    /// should call [`take_token`](Self::take_token).
-    pub async fn take_token_aliased(&mut self, is_command_name: bool) -> Result<Rec<Token>> {
+    /// call this function on a reserved word. That is why this function is named
+    /// `manual`. To consume a reserved word, you should call
+    /// [`take_token`](Self::take_token).
+    pub async fn take_token_manual(&mut self, is_command_name: bool) -> Result<Rec<Token>> {
         let token = self.take_token_raw().await?;
 
         if !self.aliases.is_empty() {
@@ -526,7 +527,7 @@ mod tests {
     }
 
     #[test]
-    fn parser_take_token_aliased_successful_substitution() {
+    fn parser_take_token_manual_successful_substitution() {
         block_on(async {
             let mut lexer = Lexer::with_source(Source::Unknown, "X");
             let mut aliases = AliasSet::new();
@@ -538,20 +539,20 @@ mod tests {
             ));
             let mut parser = Parser::with_aliases(&mut lexer, Rc::new(aliases));
 
-            let token = parser.take_token_aliased(true).await.unwrap();
+            let token = parser.take_token_manual(true).await.unwrap();
             assert!(
                 token.is_alias_substituted(),
                 "{:?} should be AliasSubstituted",
                 &token
             );
 
-            let token = parser.take_token_aliased(true).await.unwrap().unwrap();
+            let token = parser.take_token_manual(true).await.unwrap().unwrap();
             assert_eq!(token.to_string(), "x");
         });
     }
 
     #[test]
-    fn parser_take_token_aliased_not_command_name() {
+    fn parser_take_token_manual_not_command_name() {
         block_on(async {
             let mut lexer = Lexer::with_source(Source::Unknown, "X");
             let mut aliases = AliasSet::new();
@@ -563,13 +564,13 @@ mod tests {
             ));
             let mut parser = Parser::with_aliases(&mut lexer, Rc::new(aliases));
 
-            let token = parser.take_token_aliased(false).await.unwrap().unwrap();
+            let token = parser.take_token_manual(false).await.unwrap().unwrap();
             assert_eq!(token.to_string(), "X");
         });
     }
 
     #[test]
-    fn parser_take_token_aliased_not_literal() {
+    fn parser_take_token_manual_not_literal() {
         block_on(async {
             let mut lexer = Lexer::with_source(Source::Unknown, r"\X");
             let mut aliases = AliasSet::new();
@@ -587,25 +588,25 @@ mod tests {
             ));
             let mut parser = Parser::with_aliases(&mut lexer, Rc::new(aliases));
 
-            let token = parser.take_token_aliased(true).await.unwrap().unwrap();
+            let token = parser.take_token_manual(true).await.unwrap().unwrap();
             assert_eq!(token.to_string(), r"\X");
         });
     }
 
     #[test]
-    fn parser_take_token_aliased_no_match() {
+    fn parser_take_token_manual_no_match() {
         block_on(async {
             let mut lexer = Lexer::with_source(Source::Unknown, "X");
             let aliases = AliasSet::new();
             let mut parser = Parser::with_aliases(&mut lexer, Rc::new(aliases));
 
-            let token = parser.take_token_aliased(true).await.unwrap().unwrap();
+            let token = parser.take_token_manual(true).await.unwrap().unwrap();
             assert_eq!(token.to_string(), "X");
         });
     }
 
     #[test]
-    fn parser_take_token_aliased_recursive_substitution() {
+    fn parser_take_token_manual_recursive_substitution() {
         block_on(async {
             let mut lexer = Lexer::with_source(Source::Unknown, "X");
             let mut aliases = AliasSet::new();
@@ -623,33 +624,33 @@ mod tests {
             ));
             let mut parser = Parser::with_aliases(&mut lexer, Rc::new(aliases));
 
-            let token = parser.take_token_aliased(true).await.unwrap();
+            let token = parser.take_token_manual(true).await.unwrap();
             assert!(
                 token.is_alias_substituted(),
                 "{:?} should be AliasSubstituted",
                 &token
             );
 
-            let token = parser.take_token_aliased(true).await.unwrap();
+            let token = parser.take_token_manual(true).await.unwrap();
             assert!(
                 token.is_alias_substituted(),
                 "{:?} should be AliasSubstituted",
                 &token
             );
 
-            let token = parser.take_token_aliased(true).await.unwrap().unwrap();
+            let token = parser.take_token_manual(true).await.unwrap().unwrap();
             assert_eq!(token.to_string(), "X");
 
-            let token = parser.take_token_aliased(true).await.unwrap().unwrap();
+            let token = parser.take_token_manual(true).await.unwrap().unwrap();
             assert_eq!(token.to_string(), "y");
 
-            let token = parser.take_token_aliased(true).await.unwrap().unwrap();
+            let token = parser.take_token_manual(true).await.unwrap().unwrap();
             assert_eq!(token.to_string(), "x");
         });
     }
 
     #[test]
-    fn parser_take_token_aliased_after_blank_ending_substitution() {
+    fn parser_take_token_manual_after_blank_ending_substitution() {
         block_on(async {
             let mut lexer = Lexer::with_source(Source::Unknown, "X\tY");
             let mut aliases = AliasSet::new();
@@ -667,30 +668,30 @@ mod tests {
             ));
             let mut parser = Parser::with_aliases(&mut lexer, Rc::new(aliases));
 
-            let token = parser.take_token_aliased(true).await.unwrap();
+            let token = parser.take_token_manual(true).await.unwrap();
             assert!(
                 token.is_alias_substituted(),
                 "{:?} should be AliasSubstituted",
                 &token
             );
 
-            let token = parser.take_token_aliased(true).await.unwrap().unwrap();
+            let token = parser.take_token_manual(true).await.unwrap().unwrap();
             assert_eq!(token.to_string(), "X");
 
-            let token = parser.take_token_aliased(false).await.unwrap();
+            let token = parser.take_token_manual(false).await.unwrap();
             assert!(
                 token.is_alias_substituted(),
                 "{:?} should be AliasSubstituted",
                 &token
             );
 
-            let token = parser.take_token_aliased(false).await.unwrap().unwrap();
+            let token = parser.take_token_manual(false).await.unwrap().unwrap();
             assert_eq!(token.to_string(), "y");
         });
     }
 
     #[test]
-    fn parser_take_token_aliased_not_after_blank_ending_substitution() {
+    fn parser_take_token_manual_not_after_blank_ending_substitution() {
         block_on(async {
             let mut lexer = Lexer::with_source(Source::Unknown, "X\tY");
             let mut aliases = AliasSet::new();
@@ -708,23 +709,23 @@ mod tests {
             ));
             let mut parser = Parser::with_aliases(&mut lexer, Rc::new(aliases));
 
-            let token = parser.take_token_aliased(true).await.unwrap();
+            let token = parser.take_token_manual(true).await.unwrap();
             assert!(
                 token.is_alias_substituted(),
                 "{:?} should be AliasSubstituted",
                 &token
             );
 
-            let token = parser.take_token_aliased(true).await.unwrap().unwrap();
+            let token = parser.take_token_manual(true).await.unwrap().unwrap();
             assert_eq!(token.to_string(), "X");
 
-            let token = parser.take_token_aliased(false).await.unwrap().unwrap();
+            let token = parser.take_token_manual(false).await.unwrap().unwrap();
             assert_eq!(token.to_string(), "Y");
         });
     }
 
     #[test]
-    fn parser_take_token_aliased_global() {
+    fn parser_take_token_manual_global() {
         block_on(async {
             let mut lexer = Lexer::with_source(Source::Unknown, "X");
             let mut aliases = AliasSet::new();
@@ -736,14 +737,14 @@ mod tests {
             ));
             let mut parser = Parser::with_aliases(&mut lexer, Rc::new(aliases));
 
-            let token = parser.take_token_aliased(false).await.unwrap();
+            let token = parser.take_token_manual(false).await.unwrap();
             assert!(
                 token.is_alias_substituted(),
                 "{:?} should be AliasSubstituted",
                 &token
             );
 
-            let token = parser.take_token_aliased(false).await.unwrap().unwrap();
+            let token = parser.take_token_manual(false).await.unwrap().unwrap();
             assert_eq!(token.to_string(), "x");
         });
     }


### PR DESCRIPTION
- [x] Rename `take_token` to `take_token_raw`
- [x] Rename `take_token_aliased` to `take_token_manual`
- [x] Define `take_token_auto`
- [x] Use `take_token_auto` instead of `take_token_raw`
- [x] Remove `take_token_aliased_fully` in favor of `take_token_auto`
- [ ] Consider removing `take_token_raw` to take the token directly
  - Instead we might be able to make `take_token_raw` non-async
- [x] Amend documentation mentioning `take_token`, `take_token_aliased`, and `take_token_aliased_fully`