### PR TITLE
Introduce Text syntax

### DIFF
--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -981,7 +981,7 @@ mod tests {
             assert_eq!(here_docs.len(), 1);
             assert_eq!(here_docs[0].delimiter.to_string(), "END");
             assert_eq!(here_docs[0].remove_tabs, remove_tabs);
-            assert!(here_docs[0].content.units.is_empty());
+            assert_eq!(here_docs[0].content.0, []);
 
             assert!(parser.take_read_here_docs().is_empty());
 

--- a/src/parser/fromstr.rs
+++ b/src/parser/fromstr.rs
@@ -48,12 +48,12 @@ impl<T, E> Shift for Result<Option<T>, E> {
     }
 }
 
-impl FromStr for DoubleQuotable {
+impl FromStr for TextUnit {
     type Err = Error;
-    /// Parses a [`DoubleQuotable`] by `lexer.double_quotable(|_| false, |_| true)`.
-    fn from_str(s: &str) -> Result<DoubleQuotable, Error> {
+    /// Parses a [`TextUnit`] by `lexer.text_unit(|_| false, |_| true)`.
+    fn from_str(s: &str) -> Result<TextUnit, Error> {
         let mut lexer = Lexer::with_source(Source::Unknown, s);
-        block_on(lexer.double_quotable(|_| false, |_| true)).map(Option::unwrap)
+        block_on(lexer.text_unit(|_| false, |_| true)).map(Option::unwrap)
     }
 }
 
@@ -248,8 +248,8 @@ mod tests {
     use std::iter::empty;
 
     #[test]
-    fn double_quotable_from_str() {
-        let parse: DoubleQuotable = "a".parse().unwrap();
+    fn text_unit_from_str() {
+        let parse: TextUnit = "a".parse().unwrap();
         assert_eq!(parse.to_string(), "a");
     }
 

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -791,7 +791,7 @@ impl Lexer {
             matches!(c, '$' | '`' | '"' | '\\')
         }
 
-        let content = self.text(is_delimiter, is_escapable).await?.0;
+        let content = self.text(is_delimiter, is_escapable).await?;
 
         if self.skip_if(|c| c == '"').await? {
             Ok(DoubleQuote(content))
@@ -2305,7 +2305,7 @@ mod tests {
             block_on(lexer.word_unit(|c| panic!("unexpected call to is_delimiter({:?})", c)))
                 .unwrap()
                 .unwrap();
-        if let DoubleQuote(content) = result {
+        if let DoubleQuote(Text(content)) = result {
             assert_eq!(content, []);
         } else {
             panic!("unexpected result {:?}", result);
@@ -2321,7 +2321,7 @@ mod tests {
             block_on(lexer.word_unit(|c| panic!("unexpected call to is_delimiter({:?})", c)))
                 .unwrap()
                 .unwrap();
-        if let DoubleQuote(content) = result {
+        if let DoubleQuote(Text(content)) = result {
             assert_eq!(content, [Literal('a'), Literal('b'), Literal('c')]);
         } else {
             panic!("unexpected result {:?}", result);
@@ -2343,7 +2343,7 @@ mod tests {
                 .await
                 .unwrap()
                 .unwrap();
-            if let DoubleQuote(ref units) = result {
+            if let DoubleQuote(Text(ref units)) = result {
                 assert_eq!(
                     units,
                     &[

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -791,10 +791,7 @@ impl Lexer {
             matches!(c, '$' | '`' | '"' | '\\')
         }
 
-        let mut content = vec![];
-        while let Some(dq) = self.double_quotable(is_delimiter, is_escapable).await? {
-            content.push(dq);
-        }
+        let content = self.text(is_delimiter, is_escapable).await?.0;
 
         if self.skip_if(|c| c == '"').await? {
             Ok(DoubleQuote(content))

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -629,10 +629,6 @@ impl Lexer {
     /// # Errors
     ///
     /// - [SyntaxError::UnclosedCommandSubstitution]
-    ///
-    /// # Panics
-    ///
-    /// If the previously consumed character is not `$`.
     pub async fn command_substitution(
         &mut self,
         opening_location: Location,

--- a/src/parser/lex/heredoc.rs
+++ b/src/parser/lex/heredoc.rs
@@ -18,9 +18,9 @@
 
 use super::Lexer;
 use crate::parser::core::Result;
-use crate::syntax::DoubleQuotable::Literal;
 use crate::syntax::HereDoc;
 use crate::syntax::Text;
+use crate::syntax::TextUnit::Literal;
 use crate::syntax::Word;
 
 /// Here-document without a content.

--- a/src/parser/lex/heredoc.rs
+++ b/src/parser/lex/heredoc.rs
@@ -20,8 +20,8 @@ use super::Lexer;
 use crate::parser::core::Result;
 use crate::syntax::DoubleQuotable::Literal;
 use crate::syntax::HereDoc;
+use crate::syntax::Text;
 use crate::syntax::Word;
-use crate::syntax::WordUnit::Unquoted;
 
 /// Here-document without a content.
 ///
@@ -50,16 +50,12 @@ impl Lexer {
         // TODO Unquote the delimiter string
         let delimiter_string = delimiter.to_string();
         // TODO Reject if the delimiter contains a newline
-        let location = self.location().await?.clone();
-        let mut content = Word {
-            units: vec![],
-            location,
-        };
+        let mut content = Text(vec![]);
         loop {
             // TODO If the delimiter is not quoted, backslashes should be effective only before
             // expansions and newlines
             // TODO If the delimiter is quoted, the here-doc content should be literal.
-            let line = self.word(|c| c == NEWLINE).await?;
+            let line = self.text(|c| c == NEWLINE, |_| false).await?;
             // TODO Strip leading tabs depending on the here-doc operator type
             let line_string = line.to_string();
 
@@ -75,8 +71,8 @@ impl Lexer {
                 });
             }
 
-            content.units.extend(line.units);
-            content.units.push(Unquoted(Literal(NEWLINE)));
+            content.0.extend(line.0);
+            content.0.push(Literal(NEWLINE));
         }
     }
 }
@@ -104,9 +100,7 @@ mod tests {
         let heredoc = block_on(lexer.here_doc_content(heredoc)).unwrap();
         assert_eq!(heredoc.delimiter.to_string(), "END");
         assert_eq!(heredoc.remove_tabs, false);
-        assert_eq!(heredoc.content.units.len(), 0);
-        assert_eq!(heredoc.content.location.line.number.get(), 1);
-        assert_eq!(heredoc.content.location.column.get(), 1);
+        assert_eq!(heredoc.content.0, []);
 
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(location.line.number.get(), 2);
@@ -122,8 +116,6 @@ mod tests {
         assert_eq!(heredoc.delimiter.to_string(), "FOO");
         assert_eq!(heredoc.remove_tabs, false);
         assert_eq!(heredoc.content.to_string(), "content\n");
-        assert_eq!(heredoc.content.location.line.number.get(), 1);
-        assert_eq!(heredoc.content.location.column.get(), 1);
 
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(location.line.number.get(), 3);
@@ -139,8 +131,6 @@ mod tests {
         assert_eq!(heredoc.delimiter.to_string(), "BAR");
         assert_eq!(heredoc.remove_tabs, false);
         assert_eq!(heredoc.content.to_string(), "foo\n\tBAR\n\nbaz\n");
-        assert_eq!(heredoc.content.location.line.number.get(), 1);
-        assert_eq!(heredoc.content.location.column.get(), 1);
 
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(location.line.number.get(), 6);

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -122,7 +122,7 @@ pub enum WordUnit {
     SingleQuote(String),
     /// Any number of [`DoubleQuotable`]s surrounded with a pair of double
     /// quotations.
-    DoubleQuote(Vec<DoubleQuotable>),
+    DoubleQuote(Text),
     // TODO tilde expansion
 }
 
@@ -133,13 +133,7 @@ impl fmt::Display for WordUnit {
         match self {
             Unquoted(dq) => dq.fmt(f),
             SingleQuote(s) => write!(f, "'{}'", s),
-            DoubleQuote(dqs) => {
-                f.write_str("\"")?;
-                for dq in dqs {
-                    dq.fmt(f)?;
-                }
-                f.write_str("\"")
-            }
+            DoubleQuote(content) => write!(f, "\"{}\"", content),
         }
     }
 }
@@ -689,9 +683,9 @@ mod tests {
         let single_quote = SingleQuote(r#"a"b"c\"#.to_string());
         assert_eq!(single_quote.to_string(), r#"'a"b"c\'"#);
 
-        let double_quote = DoubleQuote(vec![]);
+        let double_quote = DoubleQuote(Text(vec![]));
         assert_eq!(double_quote.to_string(), "\"\"");
-        let double_quote = DoubleQuote(vec![Literal('A'), Backslashed('B')]);
+        let double_quote = DoubleQuote(Text(vec![Literal('A'), Backslashed('B')]));
         assert_eq!(double_quote.to_string(), "\"A\\B\"");
     }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -57,9 +57,9 @@ impl<T: MaybeLiteral> MaybeLiteral for [T] {
     }
 }
 
-/// Element of a [Word] that can be double-quoted.
+/// Element of a [Text], i.e., something that can be expanded.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum DoubleQuotable {
+pub enum TextUnit {
     /// Literal single character.
     Literal(char),
     /// Backslash-escaped single character.
@@ -71,9 +71,9 @@ pub enum DoubleQuotable {
     // Arith(TODO),
 }
 
-pub use DoubleQuotable::*;
+pub use TextUnit::*;
 
-impl fmt::Display for DoubleQuotable {
+impl fmt::Display for TextUnit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Literal(c) => write!(f, "{}", c),
@@ -83,7 +83,7 @@ impl fmt::Display for DoubleQuotable {
     }
 }
 
-impl MaybeLiteral for DoubleQuotable {
+impl MaybeLiteral for TextUnit {
     /// If `self` is `Literal`, appends the character to `result` and returns it.
     /// Otherwise, returns `None`.
     fn extend_if_literal<T: Extend<char>>(&self, mut result: T) -> Option<T> {
@@ -99,7 +99,7 @@ impl MaybeLiteral for DoubleQuotable {
 
 /// String that may contain some expansions.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Text(pub Vec<DoubleQuotable>);
+pub struct Text(pub Vec<TextUnit>);
 
 impl fmt::Display for Text {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -116,11 +116,11 @@ impl MaybeLiteral for Text {
 /// Element of a [Word].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum WordUnit {
-    /// Unquoted [`DoubleQuotable`] as a word unit.
-    Unquoted(DoubleQuotable),
+    /// Unquoted [`TextUnit`] as a word unit.
+    Unquoted(TextUnit),
     /// String surrounded with a pair of single quotations.
     SingleQuote(String),
-    /// Any number of [`DoubleQuotable`]s surrounded with a pair of double
+    /// Any number of [`TextUnit`]s surrounded with a pair of double
     /// quotations.
     DoubleQuote(Text),
     // TODO tilde expansion
@@ -664,7 +664,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn double_quotable_display() {
+    fn text_unit_display() {
         let literal = Literal('A');
         assert_eq!(literal.to_string(), "A");
         let backslashed = Backslashed('X');

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -50,6 +50,13 @@ pub trait MaybeLiteral {
     }
 }
 
+impl<T: MaybeLiteral> MaybeLiteral for [T] {
+    fn extend_if_literal<R: Extend<char>>(&self, result: R) -> Option<R> {
+        self.iter()
+            .try_fold(result, |result, unit| unit.extend_if_literal(result))
+    }
+}
+
 /// Element of a [Word] that can be double-quoted.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DoubleQuotable {
@@ -130,13 +137,6 @@ impl MaybeLiteral for WordUnit {
         } else {
             None
         }
-    }
-}
-
-// TODO generalize
-impl MaybeLiteral for [WordUnit] {
-    fn extend_if_literal<T: Extend<char>>(&self, result: T) -> Option<T> {
-        self.iter().try_fold(result, |result, unit| unit.extend_if_literal(result))
     }
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -97,6 +97,16 @@ impl MaybeLiteral for DoubleQuotable {
     }
 }
 
+/// String that may contain some expansions.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Text(pub Vec<DoubleQuotable>);
+
+impl fmt::Display for Text {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.iter().try_for_each(|unit| unit.fmt(f))
+    }
+}
+
 /// Element of a [Word].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum WordUnit {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -332,8 +332,8 @@ pub struct HereDoc {
     /// Content of the here-document.
     ///
     /// The content ends with a newline unless it is empty. If the delimiter
-    /// is quoted, the content must not contain any expansion.
-    pub content: Word,
+    /// is quoted, the content must be all literal.
+    pub content: Text,
 }
 
 impl fmt::Display for HereDoc {
@@ -826,14 +826,14 @@ mod tests {
         let heredoc = HereDoc {
             delimiter: Word::from_str("END").unwrap(),
             remove_tabs: true,
-            content: Word::from_str("here").unwrap(),
+            content: Text::from_str("here").unwrap(),
         };
         assert_eq!(heredoc.to_string(), "<<-END");
 
         let heredoc = HereDoc {
             delimiter: Word::from_str("XXX").unwrap(),
             remove_tabs: false,
-            content: Word::from_str("there").unwrap(),
+            content: Text::from_str("there").unwrap(),
         };
         assert_eq!(heredoc.to_string(), "<<XXX");
     }
@@ -843,14 +843,14 @@ mod tests {
         let heredoc = HereDoc {
             delimiter: Word::from_str("--").unwrap(),
             remove_tabs: false,
-            content: Word::from_str("here").unwrap(),
+            content: Text::from_str("here").unwrap(),
         };
         assert_eq!(heredoc.to_string(), "<< --");
 
         let heredoc = HereDoc {
             delimiter: Word::from_str("-").unwrap(),
             remove_tabs: true,
-            content: Word::from_str("here").unwrap(),
+            content: Text::from_str("here").unwrap(),
         };
         assert_eq!(heredoc.to_string(), "<<- -");
     }
@@ -860,7 +860,7 @@ mod tests {
         let heredoc = HereDoc {
             delimiter: Word::from_str("END").unwrap(),
             remove_tabs: false,
-            content: Word::from_str("here").unwrap(),
+            content: Text::from_str("here").unwrap(),
         };
 
         let redir = Redir {
@@ -910,7 +910,7 @@ mod tests {
             body: RedirBody::from(HereDoc {
                 delimiter: Word::from_str("END").unwrap(),
                 remove_tabs: false,
-                content: Word::from_str("").unwrap(),
+                content: Text::from_str("").unwrap(),
             }),
         });
         assert_eq!(command.to_string(), "name=value hello=world echo foo <<END");
@@ -926,7 +926,7 @@ mod tests {
             body: RedirBody::from(HereDoc {
                 delimiter: Word::from_str("here").unwrap(),
                 remove_tabs: true,
-                content: Word::from_str("ignored").unwrap(),
+                content: Text::from_str("ignored").unwrap(),
             }),
         });
         assert_eq!(command.to_string(), "<<END 1<<-here");

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -66,7 +66,13 @@ pub enum TextUnit {
     Backslashed(char),
     // Parameter(TODO),
     /// Command substitution of the form `$(...)`.
-    CommandSubst { content: String, location: Location },
+    CommandSubst {
+        /// Command string that will be parsed and executed when the command
+        /// substitution is expanded.
+        content: String,
+        /// Location of the initial `$` character of this command substitution.
+        location: Location,
+    },
     // Backquote(TODO),
     // Arith(TODO),
 }
@@ -98,6 +104,9 @@ impl MaybeLiteral for TextUnit {
 }
 
 /// String that may contain some expansions.
+///
+/// A text is a sequence of [text unit](TextUnit)s, which may contain some kinds
+/// of expansions.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Text(pub Vec<TextUnit>);
 
@@ -113,15 +122,14 @@ impl MaybeLiteral for Text {
     }
 }
 
-/// Element of a [Word].
+/// Element of a [Word], i.e., text with quotes and tilde expansion.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum WordUnit {
     /// Unquoted [`TextUnit`] as a word unit.
     Unquoted(TextUnit),
     /// String surrounded with a pair of single quotations.
     SingleQuote(String),
-    /// Any number of [`TextUnit`]s surrounded with a pair of double
-    /// quotations.
+    /// Text surrounded with a pair of double quotations.
     DoubleQuote(Text),
     // TODO tilde expansion
 }
@@ -150,10 +158,14 @@ impl MaybeLiteral for WordUnit {
     }
 }
 
-/// Token that may involve expansion.
+/// Token that may involve expansions and quotes.
 ///
-/// It depends on context whether an empty word is valid or not. It is your responsibility to
-/// ensure a word is non-empty in a context where it cannot.
+/// A word is a sequence of [word unit](WordUnit)s. It depends on context whether
+/// an empty word is valid or not. It is your responsibility to ensure a word is
+/// non-empty in a context where it cannot.
+///
+/// The difference between words and [text](Text)s is that only words can contain
+/// single- and double-quotes and tilde expansions. Compare [`WordUnit`] and [`TextUnit`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Word {
     /// Word units that constitute the word.

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -107,6 +107,12 @@ impl fmt::Display for Text {
     }
 }
 
+impl MaybeLiteral for Text {
+    fn extend_if_literal<T: Extend<char>>(&self, result: T) -> Option<T> {
+        self.0.extend_if_literal(result)
+    }
+}
+
 /// Element of a [Word].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum WordUnit {
@@ -687,6 +693,23 @@ mod tests {
         assert_eq!(double_quote.to_string(), "\"\"");
         let double_quote = DoubleQuote(vec![Literal('A'), Backslashed('B')]);
         assert_eq!(double_quote.to_string(), "\"A\\B\"");
+    }
+
+    #[test]
+    fn text_to_string_if_literal_success() {
+        let empty = Text(vec![]);
+        let s = empty.to_string_if_literal().unwrap();
+        assert_eq!(s, "");
+
+        let nonempty = Text(vec![Literal('f'), Literal('o'), Literal('o')]);
+        let s = nonempty.to_string_if_literal().unwrap();
+        assert_eq!(s, "foo");
+    }
+
+    #[test]
+    fn text_to_string_if_literal_failure() {
+        let backslashed = Text(vec![Backslashed('a')]);
+        assert_eq!(backslashed.to_string_if_literal(), None);
     }
 
     #[test]


### PR DESCRIPTION
The type name "double quotable" sounds rather awkward. The type should also be used for here-document content, arithmetic expansion content, and the array index in parameter expansion. So, this pull request renames the type to "text unit" and introduces a new type "text" to organize those syntax components.

### Refactor MaybeLiteral

- [x] Change to use Extend<char>
- [x] Blanket impl MaybeLiteral for array/iterator

### Prepare Text syntax

- [x] Define Text syntax
- [x] impl Display for Text
- [x] impl MaybeLiteral for Text

### Parse Text syntax

- [x] Parse Text
- [x] impl FromStr for Text
- [x] Use text parser to parse double quotes

### Organize data structure

- [x] Use Text in WordUnit::DoubleQuote content
- [x] Use Text for HereDoc content
- [x] Rename DoubleQuotable to TextUnit
   - Also rename appearances in comments like "double quotable"
- [x] Update doc comments
