### PR TITLE
Parsing tilde expansion syntax

### DIFF
--- a/src/parser/fromstr.rs
+++ b/src/parser/fromstr.rs
@@ -76,6 +76,12 @@ impl FromStr for WordUnit {
 
 impl FromStr for Word {
     type Err = Error;
+
+    /// Converts a string to a word.
+    ///
+    /// This function does not parse any tilde expansions in the word.
+    /// To parse them, you need to call [`Word::parse_tilde_front`] or
+    /// [`Word::parse_tilde_everywhere`] on the resultant word.
     fn from_str(s: &str) -> Result<Word, Error> {
         let mut lexer = Lexer::with_source(Source::Unknown, s);
         block_on(lexer.word(|_| false))

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -877,7 +877,8 @@ impl Lexer {
         }
 
         let index = self.index();
-        let word = self.word(is_token_delimiter_char).await?;
+        let mut word = self.word(is_token_delimiter_char).await?;
+        word.parse_tilde_front();
         let id = self.token_id(&word).await?;
         Ok(Token { word, id, index })
     }
@@ -2437,6 +2438,21 @@ mod tests {
         assert_eq!(t.index, 0);
 
         assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, ' ');
+    }
+
+    #[test]
+    fn lexer_token_tilde() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "~a:~");
+
+        let t = block_on(lexer.token()).unwrap();
+        assert_eq!(
+            t.word.units,
+            [
+                WordUnit::Tilde("a".to_string()),
+                WordUnit::Unquoted(TextUnit::Literal(':')),
+                WordUnit::Unquoted(TextUnit::Literal('~'))
+            ]
+        );
     }
 
     #[test]

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -817,14 +817,17 @@ impl Lexer {
         }
     }
 
-    // TODO Need more parameters to control how the word should be parsed. Especially:
-    //  * Allow tilde expansion?
     /// Parses a word token.
     ///
-    /// `is_delimiter` is a function that decides a character is a delimiter. The word ends when an
-    /// unquoted delimiter is found. To parse a normal word token, you should pass
-    /// [`is_token_delimiter_char`] as `is_delimiter`. Other functions can be passed to parse a
-    /// word that ends with different delimiters.
+    /// `is_delimiter` is a function that decides which character is a delimiter.
+    /// The word ends when an unquoted delimiter is found. To parse a normal word
+    /// token, you should pass [`is_token_delimiter_char`] as `is_delimiter`.
+    /// Other functions can be passed to parse a word that ends with different
+    /// delimiters.
+    ///
+    /// This function does not parse any tilde expansions in the word.
+    /// To parse them, you need to call [`Word::parse_tilde_front`] or
+    /// [`Word::parse_tilde_everywhere`] on the resultant word.
     pub async fn word<F>(&mut self, mut is_delimiter: F) -> Result<Word>
     where
         F: FnMut(char) -> bool,

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -20,6 +20,7 @@
 
 // mod heredoc; // See below
 mod op;
+mod tilde;
 
 mod core {
 

--- a/src/parser/lex/tilde.rs
+++ b/src/parser/lex/tilde.rs
@@ -1,0 +1,159 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2021 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Tilde expansion parser.
+//!
+//! TODO Elaborate
+
+use crate::syntax::TextUnit::Literal;
+use crate::syntax::Word;
+use crate::syntax::WordUnit::{Tilde, Unquoted};
+
+impl Word {
+    /// TODO
+    pub fn parse_tilde(self) -> Self {
+        if self.units.first() != Some(&Unquoted(Literal('~'))) {
+            return self;
+        }
+
+        let mut i = self.units.into_iter().peekable();
+        let tilde = i.next().unwrap();
+        debug_assert_eq!(tilde, Unquoted(Literal('~')));
+
+        // Parse the body of the tilde expansion into `name`, consuming characters from `i`.
+        let mut name = String::new();
+        while let Some(Unquoted(Literal(c))) =
+            i.next_if(|unit| matches!(unit, Unquoted(Literal(c)) if !matches!(*c, '/' | ':')))
+        {
+            name.push(c)
+        }
+
+        // Check the delimiter and create the result.
+        let mut units = match i.peek() {
+            None | Some(Unquoted(Literal(_))) => vec![Tilde(name)],
+            Some(_) => {
+                // The next word unit is not applicable for tilde expansion.
+                // Revert to the original literals.
+                let mut units = vec![Unquoted(Literal('~'))];
+                units.extend(name.chars().map(|c| Unquoted(Literal(c))));
+                units
+            }
+        };
+        units.extend(i);
+        Word { units, ..self }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::syntax::Text;
+    use crate::syntax::TextUnit::Backslashed;
+    use crate::syntax::WordUnit::{DoubleQuote, SingleQuote};
+    use std::str::FromStr;
+
+    #[test]
+    fn word_parse_tilde_not_starting_with_tilde() {
+        let input = Word::from_str("").unwrap();
+        let result = input.clone().parse_tilde();
+        assert_eq!(result, input);
+
+        let input = Word::from_str("a").unwrap();
+        let result = input.clone().parse_tilde();
+        assert_eq!(result, input);
+
+        let input = Word::from_str("''").unwrap();
+        let result = input.clone().parse_tilde();
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn word_parse_tilde_only_tilde() {
+        let input = Word::from_str("~").unwrap();
+        let result = input.clone().parse_tilde();
+        assert_eq!(result.location, input.location);
+        assert_eq!(result.units, [Tilde("".to_string())]);
+    }
+
+    #[test]
+    fn word_parse_tilde_with_name() {
+        let input = Word::from_str("~foo").unwrap();
+        let result = input.clone().parse_tilde();
+        assert_eq!(result.location, input.location);
+        assert_eq!(result.units, [Tilde("foo".to_string())]);
+    }
+
+    #[test]
+    fn word_parse_tilde_ending_with_slash() {
+        let input = Word::from_str("~bar/''").unwrap();
+        let result = input.clone().parse_tilde();
+        assert_eq!(result.location, input.location);
+        assert_eq!(
+            result.units,
+            [
+                Tilde("bar".to_string()),
+                Unquoted(Literal('/')),
+                SingleQuote("".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn word_parse_tilde_ending_with_colon() {
+        let input = Word::from_str("~bar:\"\"").unwrap();
+        let result = input.clone().parse_tilde();
+        assert_eq!(result.location, input.location);
+        assert_eq!(
+            result.units,
+            [
+                Tilde("bar".to_string()),
+                Unquoted(Literal(':')),
+                DoubleQuote(Text(vec![])),
+            ]
+        );
+    }
+
+    #[test]
+    fn word_parse_tilde_interrupted_by_non_literal() {
+        let input = Word::from_str(r"~foo\/").unwrap();
+        let result = input.clone().parse_tilde();
+        assert_eq!(result.location, input.location);
+        assert_eq!(
+            result.units,
+            [
+                Unquoted(Literal('~')),
+                Unquoted(Literal('f')),
+                Unquoted(Literal('o')),
+                Unquoted(Literal('o')),
+                Unquoted(Backslashed('/')),
+            ]
+        );
+
+        let input = Word::from_str("~bar''").unwrap();
+        let result = input.clone().parse_tilde();
+        assert_eq!(result.location, input.location);
+        assert_eq!(
+            result.units,
+            [
+                Unquoted(Literal('~')),
+                Unquoted(Literal('b')),
+                Unquoted(Literal('a')),
+                Unquoted(Literal('r')),
+                SingleQuote("".to_string()),
+            ]
+        );
+    }
+}

--- a/src/parser/lex/tilde.rs
+++ b/src/parser/lex/tilde.rs
@@ -40,48 +40,6 @@ fn parse_name<I: Iterator<Item = WordUnit>>(i: &mut Peekable<I>) -> String {
 
 impl Word {
     fn parse_tilde(&mut self) {
-        if self.units.first() != Some(&Unquoted(Literal('~'))) {
-            return;
-        }
-
-        let mut i = self.units.drain(..).peekable();
-        let tilde = i.next().unwrap();
-        debug_assert_eq!(tilde, Unquoted(Literal('~')));
-
-        // Parse the body of the tilde expansion into `name`, consuming characters from `i`.
-        let mut name = String::new();
-        while let Some(Unquoted(Literal(c))) =
-            i.next_if(|unit| matches!(unit, Unquoted(Literal(c)) if !matches!(*c, '/' | ':')))
-        {
-            name.push(c)
-        }
-
-        // Check the delimiter and create the result.
-        let mut units = match i.peek() {
-            None | Some(Unquoted(Literal(_))) => vec![Tilde(name)],
-            Some(_) => {
-                // The next word unit is not applicable for tilde expansion.
-                // Revert to the original literals.
-                let mut units = vec![Unquoted(Literal('~'))];
-                units.extend(name.chars().map(|c| Unquoted(Literal(c))));
-                units
-            }
-        };
-        units.extend(i);
-        self.units = units;
-    }
-
-    /// TODO Describe
-    ///
-    /// TODO Describe about difference from strictly POSIX-conforming behavior
-    #[inline]
-    pub fn parse_tilde_front(&mut self) {
-        self.parse_tilde()
-    }
-
-    /// TODO Describe
-    #[inline]
-    pub fn parse_tilde_everywhere(&mut self) {
         let mut i = self.units.drain(..).peekable();
         let mut is_after_colon = true;
         let mut units = vec![];
@@ -118,6 +76,20 @@ impl Word {
 
         drop(i);
         self.units = units;
+    }
+
+    /// TODO Describe
+    ///
+    /// TODO Describe about difference from strictly POSIX-conforming behavior
+    #[inline]
+    pub fn parse_tilde_front(&mut self) {
+        self.parse_tilde()
+    }
+
+    /// TODO Describe
+    #[inline]
+    pub fn parse_tilde_everywhere(&mut self) {
+        self.parse_tilde()
     }
 }
 

--- a/src/parser/lex/tilde.rs
+++ b/src/parser/lex/tilde.rs
@@ -23,8 +23,7 @@ use crate::syntax::Word;
 use crate::syntax::WordUnit::{Tilde, Unquoted};
 
 impl Word {
-    /// TODO
-    pub fn parse_tilde(self) -> Self {
+    fn parse_tilde(self) -> Self {
         if self.units.first() != Some(&Unquoted(Literal('~'))) {
             return self;
         }
@@ -55,6 +54,14 @@ impl Word {
         units.extend(i);
         Word { units, ..self }
     }
+
+    /// TODO Describe
+    ///
+    /// TODO Describe about difference from strictly POSIX-conforming behavior
+    #[inline]
+    pub fn parse_tilde_front(self) -> Self {
+        self.parse_tilde()
+    }
 }
 
 #[cfg(test)]
@@ -66,40 +73,40 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn word_parse_tilde_not_starting_with_tilde() {
+    fn word_parse_tilde_front_not_starting_with_tilde() {
         let input = Word::from_str("").unwrap();
-        let result = input.clone().parse_tilde();
+        let result = input.clone().parse_tilde_front();
         assert_eq!(result, input);
 
         let input = Word::from_str("a").unwrap();
-        let result = input.clone().parse_tilde();
+        let result = input.clone().parse_tilde_front();
         assert_eq!(result, input);
 
         let input = Word::from_str("''").unwrap();
-        let result = input.clone().parse_tilde();
+        let result = input.clone().parse_tilde_front();
         assert_eq!(result, input);
     }
 
     #[test]
-    fn word_parse_tilde_only_tilde() {
+    fn word_parse_tilde_front_only_tilde() {
         let input = Word::from_str("~").unwrap();
-        let result = input.clone().parse_tilde();
+        let result = input.clone().parse_tilde_front();
         assert_eq!(result.location, input.location);
         assert_eq!(result.units, [Tilde("".to_string())]);
     }
 
     #[test]
-    fn word_parse_tilde_with_name() {
+    fn word_parse_tilde_front_with_name() {
         let input = Word::from_str("~foo").unwrap();
-        let result = input.clone().parse_tilde();
+        let result = input.clone().parse_tilde_front();
         assert_eq!(result.location, input.location);
         assert_eq!(result.units, [Tilde("foo".to_string())]);
     }
 
     #[test]
-    fn word_parse_tilde_ending_with_slash() {
+    fn word_parse_tilde_front_ending_with_slash() {
         let input = Word::from_str("~bar/''").unwrap();
-        let result = input.clone().parse_tilde();
+        let result = input.clone().parse_tilde_front();
         assert_eq!(result.location, input.location);
         assert_eq!(
             result.units,
@@ -112,9 +119,9 @@ mod tests {
     }
 
     #[test]
-    fn word_parse_tilde_ending_with_colon() {
+    fn word_parse_tilde_front_ending_with_colon() {
         let input = Word::from_str("~bar:\"\"").unwrap();
-        let result = input.clone().parse_tilde();
+        let result = input.clone().parse_tilde_front();
         assert_eq!(result.location, input.location);
         assert_eq!(
             result.units,
@@ -127,9 +134,9 @@ mod tests {
     }
 
     #[test]
-    fn word_parse_tilde_interrupted_by_non_literal() {
+    fn word_parse_tilde_front_interrupted_by_non_literal() {
         let input = Word::from_str(r"~foo\/").unwrap();
-        let result = input.clone().parse_tilde();
+        let result = input.clone().parse_tilde_front();
         assert_eq!(result.location, input.location);
         assert_eq!(
             result.units,
@@ -143,7 +150,7 @@ mod tests {
         );
 
         let input = Word::from_str("~bar''").unwrap();
-        let result = input.clone().parse_tilde();
+        let result = input.clone().parse_tilde_front();
         assert_eq!(result.location, input.location);
         assert_eq!(
             result.units,

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -197,7 +197,10 @@ pub enum WordUnit {
     SingleQuote(String),
     /// Text surrounded with a pair of double quotations.
     DoubleQuote(Text),
-    // TODO tilde expansion
+    /// Tilde expansion.
+    ///
+    /// The `String` value does not contain the initial tilde.
+    Tilde(String),
 }
 
 pub use WordUnit::*;
@@ -208,6 +211,7 @@ impl fmt::Display for WordUnit {
             Unquoted(dq) => dq.fmt(f),
             SingleQuote(s) => write!(f, "'{}'", s),
             DoubleQuote(content) => write!(f, "\"{}\"", content),
+            Tilde(s) => write!(f, "~{}", s),
         }
     }
 }
@@ -221,6 +225,10 @@ impl Unquote for WordUnit {
                 Ok(true)
             }
             DoubleQuote(inner) => inner.write_unquoted(w),
+            Tilde(s) => {
+                write!(w, "~{}", s)?;
+                Ok(false)
+            }
         }
     }
 }
@@ -774,24 +782,6 @@ mod tests {
     }
 
     #[test]
-    fn word_unit_display() {
-        let unquoted = Unquoted(Literal('A'));
-        assert_eq!(unquoted.to_string(), "A");
-        let unquoted = Unquoted(Backslashed('B'));
-        assert_eq!(unquoted.to_string(), "\\B");
-
-        let single_quote = SingleQuote("".to_string());
-        assert_eq!(single_quote.to_string(), "''");
-        let single_quote = SingleQuote(r#"a"b"c\"#.to_string());
-        assert_eq!(single_quote.to_string(), r#"'a"b"c\'"#);
-
-        let double_quote = DoubleQuote(Text(vec![]));
-        assert_eq!(double_quote.to_string(), "\"\"");
-        let double_quote = DoubleQuote(Text(vec![Literal('A'), Backslashed('B')]));
-        assert_eq!(double_quote.to_string(), "\"A\\B\"");
-    }
-
-    #[test]
     fn text_from_literal_chars() {
         let text = Text::from_literal_chars(['a', '1'].iter().copied());
         assert_eq!(text.0, [Literal('a'), Literal('1')]);
@@ -844,10 +834,33 @@ mod tests {
     }
 
     #[test]
+    fn word_unit_display() {
+        let unquoted = Unquoted(Literal('A'));
+        assert_eq!(unquoted.to_string(), "A");
+        let unquoted = Unquoted(Backslashed('B'));
+        assert_eq!(unquoted.to_string(), "\\B");
+
+        let single_quote = SingleQuote("".to_string());
+        assert_eq!(single_quote.to_string(), "''");
+        let single_quote = SingleQuote(r#"a"b"c\"#.to_string());
+        assert_eq!(single_quote.to_string(), r#"'a"b"c\'"#);
+
+        let double_quote = DoubleQuote(Text(vec![]));
+        assert_eq!(double_quote.to_string(), "\"\"");
+        let double_quote = DoubleQuote(Text(vec![Literal('A'), Backslashed('B')]));
+        assert_eq!(double_quote.to_string(), "\"A\\B\"");
+
+        let tilde = Tilde("".to_string());
+        assert_eq!(tilde.to_string(), "~");
+        let tilde = Tilde("foo".to_string());
+        assert_eq!(tilde.to_string(), "~foo");
+    }
+
+    #[test]
     fn word_unquote() {
-        let word = Word::from_str(r#"a\b'c'"d""#).unwrap();
+        let word = Word::from_str(r#"~a/b\c'd'"e""#).unwrap();
         let (unquoted, is_quoted) = word.unquote();
-        assert_eq!(unquoted, "abcd");
+        assert_eq!(unquoted, "~a/bcde");
         assert_eq!(is_quoted, true);
     }
 
@@ -857,9 +870,9 @@ mod tests {
         let s = empty.to_string_if_literal().unwrap();
         assert_eq!(s, "");
 
-        let nonempty = Word::from_str("foo").unwrap();
+        let nonempty = Word::from_str("~foo").unwrap();
         let s = nonempty.to_string_if_literal().unwrap();
-        assert_eq!(s, "foo");
+        assert_eq!(s, "~foo");
     }
 
     #[test]
@@ -869,6 +882,12 @@ mod tests {
         let word = Word {
             units: vec![backslashed],
             location,
+        };
+        assert_eq!(word.to_string_if_literal(), None);
+
+        let word = Word {
+            units: vec![Tilde("foo".to_string())],
+            ..word
         };
         assert_eq!(word.to_string_if_literal(), None);
     }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -337,7 +337,7 @@ impl TryFrom<Word> for Assign {
                 if let Some(name) = word.units[..eq].to_string_if_literal() {
                     assert!(!name.is_empty());
                     word.units.drain(..=eq);
-                    // TODO parse tilde expansions in the value
+                    word.parse_tilde_everywhere();
                     let location = word.location.clone();
                     let value = Scalar(word);
                     return Ok(Assign {
@@ -964,6 +964,24 @@ mod tests {
             panic!("wrong value: {:?}", assign.value);
         }
         assert_eq!(assign.location, location);
+    }
+
+    #[test]
+    fn assign_try_from_word_tilde() {
+        let word = Word::from_str("a=~:~b").unwrap();
+        let assign = Assign::try_from(word).unwrap();
+        if let Scalar(value) = assign.value {
+            assert_eq!(
+                value.units,
+                [
+                    WordUnit::Tilde("".to_string()),
+                    WordUnit::Unquoted(TextUnit::Literal(':')),
+                    WordUnit::Tilde("b".to_string()),
+                ]
+            );
+        } else {
+            panic!("wrong value: {:?}", assign.value);
+        }
     }
 
     #[test]


### PR DESCRIPTION
- [x] Define syntax
- [x] Define parser (Conversion from `Word` to `Word`)
- Use parser
   - [x] For tokens
   - [x] For scalar assignment values
- [x] Document `Word::from_str` about tilde expansion
- [ ] Refactor